### PR TITLE
don't use avatar url

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -2904,8 +2904,8 @@ code:hover .copybutton {
 
 /*-----DEV-----*/
 
-.avatar-small[style='background-image: url("https://cdn.discordapp.com/avatars/86477779717066752/9168bf00df1b8dd5658ddd5fc8a8a67b.jpg");']+.member-inner .member-username .member-username-inner:after,
-.avatar-large[style='background-image: url("https://cdn.discordapp.com/avatars/86477779717066752/9168bf00df1b8dd5658ddd5fc8a8a67b.jpg");']+.comment .username-wrapper .user-name:after {
+.avatar-small[style*='86477779717066752']+.member-inner .member-username .member-username-inner:after,
+.avatar-large[style*='86477779717066752']+.comment .username-wrapper .user-name:after {
     content: "Developer";
     background: #108aa5;
     margin-left: 5px;
@@ -2915,7 +2915,7 @@ code:hover .copybutton {
     border-radius: 4px;
 }
 
-.avatar-large[style='background-image: url("https://cdn.discordapp.com/avatars/86477779717066752/9168bf00df1b8dd5658ddd5fc8a8a67b.jpg");']+.comment .username-wrapper .user-name:after {
+.avatar-large[style*='86477779717066752']+.comment .username-wrapper .user-name:after {
     -webkit-transition: all 200ms ease;
     transition: all 200ms ease
 }


### PR DESCRIPTION
Accidentally made a fork, so thought "might as well do something with it".

Basically, the way you did you developer tag was to look at your avatar URL. That's all find and dandy and all, but will break if you ever change your avatar (hash changes).

Instead, make it look to see if the url *contains your user id*. This makes it static regardless of whether or not you change your avatar.

You could also achieve the same effect by doing
```
style*='background-image: url("https://cdn.discordapp.com/avatars/86477779717066752'
```
which checks for the entire beginning of your style, which makes it less likely to overlap.